### PR TITLE
Better performance of the bookmarks bar

### DIFF
--- a/htdocs/lib/BookmarkBar.js
+++ b/htdocs/lib/BookmarkBar.js
@@ -50,10 +50,16 @@ function BookmarkBar() {
     });
 }
 
-BookmarkBar.prototype.position = function(){
+BookmarkBar.prototype.position = function () {
+    var waterfallWidth = $('body').width();
     var range = get_visible_freq_range();
-    $('#openwebrx-bookmarks-container').find('.bookmark').each(function(){
-        $(this).css('left', scale_px_from_freq($(this).data('frequency'), range));
+    $('#openwebrx-bookmarks-container').find('.bookmark').each(function () {
+        const px = scale_px_from_freq($(this).data('frequency'), range);
+        const visible = px >= -32 && px <= waterfallWidth + 32;
+        $(this).toggle(visible);
+        if (visible) {
+            $(this).css('left', px);
+        }
     });
 };
 


### PR DESCRIPTION
## Overview

Rendering every bookmark on large-bandwidth, shortwave waterfalls was hammering the UI: every pan or zoom forced the browser to reposition every bookmark, tanking frame rates.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/f551d80d-fe4d-4743-af14-e5565a175936" />

## What’s changed

BookmarkBar.prototype.position() now:

1. Calculates each bookmark’s pixel position (px).
2. Checks whether that px sits within the viewport (±32 px buffer).
3. Updates left only for visible bookmarks and simply hides the rest with .toggle(visible).

By skipping style writes for off-screen elements we eliminate unnecessary reflows and layout thrashing.

## Results

- Firefox sustains its peak frame rate with hundreds of bookmarks.
- Chrome, Edge, and Safari show markedly lower CPU usage and zero “jank” while scrolling or zooming.
- Overall navigation across wide frequency spans feels fluid and responsive.

Existing functionality is unchanged; performance under heavy loads is just much better.